### PR TITLE
Fix staff highlight colour

### DIFF
--- a/about.json
+++ b/about.json
@@ -16,7 +16,7 @@
         "background": "FBFBFB",
         "header_background": "FFFFFF",
         "header_primary": "333333",
-        "highlight": "F1F2F2",
+        "highlight": "ffff80",
         "danger": "F4595B",
         "success": "3069F0",
         "love": "F4595B"
@@ -28,7 +28,7 @@
         "quaternary": "D7FFFE",
         "header_background": "23282D",
         "header_primary": "F6F6F6",
-        "highlight": "555555",
+        "highlight": "004080",
         "danger": "F67A7B",
         "success": "64EDC0",
         "love": "F288E9"

--- a/about.json
+++ b/about.json
@@ -9,12 +9,13 @@
     },
     "color_schemes": {
       "light": {
-        "primary": "222",
-        "secondary": "FFF",
+        "primary": "222222",
+        "secondary": "FBFBFB",
         "tertiary": "141C3A",
         "quaternary": "141C3A",
-        "header_background": "FFF",
-        "header_primary": "333",
+        "background": "FBFBFB",
+        "header_background": "FFFFFF",
+        "header_primary": "333333",
         "highlight": "F1F2F2",
         "danger": "F4595B",
         "success": "3069F0",
@@ -22,15 +23,15 @@
       },
       "dark": {
         "primary": "F6F6F6",
-        "secondary": "333",
-        "tertiary": "d7fffe",
-        "quaternary": "d7fffe",
+        "secondary": "333333",
+        "tertiary": "D7FFFE",
+        "quaternary": "D7FFFE",
         "header_background": "23282D",
         "header_primary": "F6F6F6",
-        "highlight": "555",
-        "danger": "f67a7b",
-        "success": "64edc0",
-        "love": "f288e9"
+        "highlight": "555555",
+        "danger": "F67A7B",
+        "success": "64EDC0",
+        "love": "F288E9"
       }
     }
   }


### PR DESCRIPTION
As briefly discussed [here](https://projectnu.org/t/group-icons-titles/133/22?u=lyall), currently, the staff highlight on light mode is practically invisible, and the dark mode is still very similar, albeit a little more visible. This changes the highlight colour on both themes to a more visible highlighted yellow on light mode:
![image](https://user-images.githubusercontent.com/78568904/176955463-ec2adf05-1999-4f2c-8f28-f1d512dce80d.png)

And a blue on dark mode:
![image](https://user-images.githubusercontent.com/78568904/176955489-33e9b760-27b7-4ca6-9023-8048f7b3b084.png)

NB: I picked these pretty arbitrarily and am more than happy to change them any further 😄 